### PR TITLE
Taking care of time-steps in the middle of the hour

### DIFF
--- a/var/repos/builtin/recipes/ouranos-mrcc5-cmip6/mrcc5-cmip6.sh
+++ b/var/repos/builtin/recipes/ouranos-mrcc5-cmip6/mrcc5-cmip6.sh
@@ -351,14 +351,17 @@ for modelMember in "${modelArr[@]}"; do
           done # until ncks
 
           # statement for ncap2
-          minute="$(date --date "$(ncks --dt_fmt=1 --cal -v time -C --jsn "${src}" | jq -r ".variables.time.data[0]")" +"%M")"
+          # some scenarios and variable have time-stamps at the middle of
+          # the hours, rather than the top. The following lines can take
+          # care of these hiccups.
+          # minute="$(date --date "$(ncks --dt_fmt=1 --cal -v time -C --jsn "${src}" | jq -r ".variables.time.data[0]")" +"%M")"
 
-          if [[ "$minute" == "30" ]] ||
-             [[ "$minute" == "29" ]]; then
-            ncap2Statement="where(lon>0) lon=lon-360; time=time-1.0/48.0" # shift for half an hour (1/48th of a day)
-          else
-            ncap2Statement="where(lon>0) lon=lon-360;" # no shift required
-          fi
+          # if [[ "$minute" == "30" ]] ||
+          #    [[ "$minute" == "29" ]]; then
+          #   ncap2Statement="where(lon>0) lon=lon-360; time=time-1.0/48.0" # shift for half an hour (1/48th of a day)
+          # else
+          #   ncap2Statement="where(lon>0) lon=lon-360;" # no shift required
+          # fi
 
           # change lon values so the extents are from ~-180 to 0
           # this is solely for easymore compatibility

--- a/var/repos/builtin/recipes/ouranos-mrcc5-cmip6/mrcc5-cmip6.sh
+++ b/var/repos/builtin/recipes/ouranos-mrcc5-cmip6/mrcc5-cmip6.sh
@@ -236,7 +236,7 @@ range=$(seq $startYear $interval $endYear)
 
 # date formats
 subsetStartFormat="%Y-%m-%dT%H:00:00"
-subsetEndFormat="%Y-%m-%dT%H:30:00"
+subsetEndFormat="%Y-%m-%dT%H:45:00"
 
 # empty arrays
 startDateArray=()
@@ -263,7 +263,7 @@ for iter in $range; do
   endValueYear="$(date --date "${endValueSub}" +"%Y")"
   # double-check end-date
   if [[ "$endValueYear" -gt 2100 ]]; then
-    endValue="2100-12-31T23:30:00" # irregular last date for dataset files
+    endValue="2100-12-31T23:45:00" # irregular last date for dataset files
   fi
 
   # fill up arrays
@@ -353,7 +353,8 @@ for modelMember in "${modelArr[@]}"; do
           # statement for ncap2
           minute="$(date --date "$(ncks --dt_fmt=1 --cal -v time -C --jsn "${src}" | jq -r ".variables.time.data[0]")" +"%M")"
 
-          if [[ "$minute" == "30" ]]; then
+          if [[ "$minute" == "30" ]] ||
+             [[ "$minute" == "29" ]]; then
             ncap2Statement="where(lon>0) lon=lon-360; time=time-1.0/48.0" # shift for half an hour (1/48th of a day)
           else
             ncap2Statement="where(lon>0) lon=lon-360;" # no shift required


### PR DESCRIPTION
In cases, the middle hour time-step was printed as HH:29:599999 so it cause issues with time shift, as 29 != 30 (30 was the assumption previosuly).

Furthermore, the last time step of subsetting is assumed to be HH:45:00 so as to no miss time-steps where the value is set to HH:30:00001 (slightly past HH:30:00).

Reported-by: Mohamed Elshamy <mohamed.elshamy@usask.ca> @mee067